### PR TITLE
mypage画面のタスク取得表示・完了機能実装、ヘッダーロゴ仮設置

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -6,12 +6,12 @@
     <div class="header__actions">
       <ng-template #default>
         <button
-          mat-raised-button
-          color="primary"
+          class="btn"
           (click)="login()"
+          [class.disabled]="authService.loginProcessing"
           [disabled]="authService.loginProcessing"
         >
-          {{ authService.loginProcessing ? 'ログイン中' : 'Twitterでログイン' }}
+          {{ authService.loginProcessing ? 'ログイン中' : 'Twitterで始める' }}
         </button>
       </ng-template>
       <ng-container *ngIf="user$ | async as user; else default">

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <mat-toolbar class="header">
   <mat-toolbar-row class="header__inner">
     <h1 class="header__logo">
-      <a routerLink="/"> Twitter Project </a>
+      <a routerLink="/">時限ツイート</a>
     </h1>
     <div class="header__actions">
       <ng-template #default>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -7,6 +7,9 @@
     height: 56px;
   }
   &__logo {
+    // font-family: 'Kosugi Maru', sans-serif;
+    font-family: 'M PLUS 1p', sans-serif;
+    font-weight: 500;
     a {
       color: $color-font;
       text-decoration: none;

--- a/src/app/interfaces/task.ts
+++ b/src/app/interfaces/task.ts
@@ -4,5 +4,6 @@ export interface Task {
   id: string;
   title: string;
   isComplate: boolean;
+  createDate: string;
   createdAt: firestore.Timestamp;
 }

--- a/src/app/interfaces/task.ts
+++ b/src/app/interfaces/task.ts
@@ -1,9 +1,8 @@
 import { firestore } from 'firebase';
 
 export interface Task {
-  id: string;
-  title: string;
-  isComplate: boolean;
-  createDate: string;
-  createdAt: firestore.Timestamp;
+  id?: string;
+  title?: string;
+  isComplate?: boolean;
+  createdAt?: firestore.Timestamp;
 }

--- a/src/app/mypage/mypage.module.ts
+++ b/src/app/mypage/mypage.module.ts
@@ -5,8 +5,6 @@ import { MypageRoutingModule } from './mypage-routing.module';
 import { MypageComponent } from './mypage/mypage.component';
 
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { MatIconModule } from '@angular/material/icon';
-import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -19,8 +17,6 @@ import { MatCardModule } from '@angular/material/card';
     MypageRoutingModule,
     ReactiveFormsModule,
     FormsModule,
-    MatIconModule,
-    MatButtonModule,
     MatFormFieldModule,
     MatInputModule,
     MatDialogModule,

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -7,7 +7,7 @@
         自分の過去ツイートが自動リツイートされます😱
       </p>
       <ng-container *ngIf="authService.afUser$ | async as user">
-        <ng-container *ngIf="userTask; else unCreate">
+        <ng-container *ngIf="userTask$ | async as userTask; else unCreate">
           <mat-card class="mypage__card">
             <dl class="mypage__data">
               <dt>今日の目標</dt>
@@ -15,21 +15,20 @@
             </dl>
             <ng-container *ngIf="userTask.isComplate; else unComplate">
               <div class="mypage__congratulations">
+                <p class="emoji">🥳</p>
                 <p>
                   おめでとうございます！<br />
                   自動リツイートは回避されました！
                 </p>
-                <p class="emoji">🥳</p>
               </div>
             </ng-container>
             <ng-template #unComplate>
               <div class="mypage__actions">
                 <button
-                  mat-raised-button
-                  color="primary"
-                  (click)="complateTask()"
+                  class="btn"
+                  (click)="complateTask(user.uid, formatToday)"
                 >
-                  完了報告
+                  完了報告する
                 </button>
               </div>
             </ng-template>
@@ -59,8 +58,8 @@
             </form>
             <div class="mypage__actions">
               <button
-                mat-flat-button
-                color="primary"
+                class="btn"
+                [class.disabled]="form.invalid || form.pristine"
                 [disabled]="form.invalid || form.pristine"
                 (click)="creatTask(user.uid)"
               >

--- a/src/app/mypage/mypage/mypage.component.scss
+++ b/src/app/mypage/mypage/mypage.component.scss
@@ -8,7 +8,7 @@
 .mypage {
   &__title {
     margin: 0;
-    padding: 10px 16px;
+    padding: 16px;
     background-color: $color-font;
     color: #ffffff;
     font-size: 14px;
@@ -16,10 +16,16 @@
     line-height: 1;
   }
   &__contents {
-    background-color: $color-main;
+    background: linear-gradient(
+      135deg,
+      $color-main 0%,
+      $color-main 75%,
+      $color-main-dark 75%,
+      $color-main-dark 100%
+    );
     padding-top: 80px;
     padding-bottom: 80px;
-    min-height: calc(100vh - (56px + 34px + 56px));
+    min-height: calc(100vh - (56px + 46px + 56px));
   }
   &__description {
     margin: 0 0 40px;

--- a/src/app/mypage/mypage/mypage.component.scss
+++ b/src/app/mypage/mypage/mypage.component.scss
@@ -53,7 +53,7 @@
     }
     .emoji {
       font-size: 40px;
-      margin: 20px 0 0;
+      margin: 0 0 16px;
     }
   }
   &__data {

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -16,7 +16,7 @@ import { TaskService } from 'src/app/services/task.service';
 export class MypageComponent implements OnInit {
   limitTime = 24;
   formatToday = this.taskService.formatToday();
-  userTask$;
+  userTask$: Observable<Task>;
   taskTitleMaxLength = 20;
 
   form = this.fb.group({
@@ -45,8 +45,8 @@ export class MypageComponent implements OnInit {
       });
   }
 
-  getTodayTask(uid: string) {
-    this.userTask$ = this.taskService.getTodayTask(uid);
+  getTodayTask(uid: string): Observable<Task> {
+    return this.taskService.getTodayTask(uid);
   }
 
   creatTask(uid: string) {
@@ -55,8 +55,8 @@ export class MypageComponent implements OnInit {
     });
   }
 
-  complateTask(uid: string, createDate: string) {
-    this.taskService.complateTask(uid, createDate);
+  complateTask(uid: string, taskId: string) {
+    this.taskService.complateTask(uid, taskId);
     this.snackBar.open('お疲れ様でした 🎉');
   }
 }

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { firestore } from 'firebase';
 import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { Task } from 'src/app/interfaces/task';

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { firestore } from 'firebase';
+import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { Task } from 'src/app/interfaces/task';
 import { AuthService } from 'src/app/services/auth.service';
@@ -14,8 +15,8 @@ import { TaskService } from 'src/app/services/task.service';
 })
 export class MypageComponent implements OnInit {
   limitTime = 24;
-  // userTasks$;
-  userTask: Task;
+  formatToday = this.taskService.formatToday();
+  userTask$;
   taskTitleMaxLength = 20;
 
   form = this.fb.group({
@@ -37,28 +38,25 @@ export class MypageComponent implements OnInit {
       .pipe(take(1))
       .toPromise()
       .then((user) => {
-        // this.userTasks$ = this.getTodayTask(user.uid);
+        this.userTask$ = this.getTodayTask(user.uid);
+        console.log(user.uid); // uidが表示 OK
+        console.log(this.formatToday); // yyyymmdd形式で表示 OK
+        console.log(this.getTodayTask(user.uid)); // undifindになる
       });
   }
 
   getTodayTask(uid: string) {
-    // this.userTasks$ = this.taskService.getTodayTask(uid);
+    this.userTask$ = this.taskService.getTodayTask(uid);
   }
 
   creatTask(uid: string) {
-    this.userTask = {
-      id: 'test',
-      title: this.form.value.title,
-      isComplate: false,
-      createdAt: firestore.Timestamp.now(),
-    };
     this.taskService.createTask(uid, this.form.value.title).then(() => {
       this.snackBar.open('目標を登録しました！');
     });
   }
 
-  complateTask() {
-    this.userTask.isComplate = true;
+  complateTask(uid: string, createDate: string) {
+    this.taskService.complateTask(uid, createDate);
     this.snackBar.open('お疲れ様でした 🎉');
   }
 }

--- a/src/app/services/task.service.ts
+++ b/src/app/services/task.service.ts
@@ -26,7 +26,7 @@ export class TaskService {
     const formatDate = {
       year: this.formatDate(today.getFullYear()),
       month: this.formatDate(today.getMonth() + 1),
-      date: this.formatDate(today.getDate())
+      date: this.formatDate(today.getDate()),
     };
     return formatDate.year + formatDate.month + formatDate.date;
   }
@@ -48,7 +48,7 @@ export class TaskService {
 
   complateTask(uid: string, createDate: string) {
     return this.db.doc(`users/${uid}/tasks/${createDate}`).update({
-      isComplate: true
+      isComplate: true,
     });
   }
 }

--- a/src/app/services/task.service.ts
+++ b/src/app/services/task.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { firestore } from 'firebase';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Task } from '../interfaces/task';
 
 @Injectable({
@@ -30,19 +31,17 @@ export class TaskService {
     return formatDate.year + formatDate.month + formatDate.date;
   }
 
-  getTodayTask(uid: string) {
+  getTodayTask(uid: string): Observable<Task> {
     const today = this.formatToday();
     return this.db.doc(`users/${uid}/tasks/${today}`).valueChanges();
   }
 
-  createTask(uid: string, taskTitle: string): Promise<void> {
-    const taskId = this.db.createId();
-    const createDate = this.formatToday();
-    return this.db.doc(`users/${uid}/tasks/${createDate}`).set({
+  createTask(uid: string, taskTitle: string) {
+    const taskId = this.formatToday();
+    return this.db.doc(`users/${uid}/tasks/${taskId}`).set({
       id: taskId,
       title: taskTitle,
       isComplate: false,
-      createDate,
       createdAt: firestore.Timestamp.now(),
     });
   }

--- a/src/app/services/task.service.ts
+++ b/src/app/services/task.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { firestore } from 'firebase';
 import { Observable } from 'rxjs';
+import { Task } from '../interfaces/task';
 
 @Injectable({
   providedIn: 'root',
@@ -9,18 +10,46 @@ import { Observable } from 'rxjs';
 export class TaskService {
   constructor(private db: AngularFirestore) {}
 
-  getTodayTask(uid: string): Observable<any> {
-    // TODO 今日のタスクを取得する
-    return this.db.doc(`users/${uid}/tasks`).valueChanges();
+  formatDate(i: number): string {
+    let num;
+    if (i < 10) {
+      num = '0' + i;
+    } else {
+      num = String(i);
+    }
+    return num;
+  }
+
+  formatToday() {
+    const today = new Date();
+    const formatDate = {
+      year: this.formatDate(today.getFullYear()),
+      month: this.formatDate(today.getMonth() + 1),
+      date: this.formatDate(today.getDate())
+    };
+    return formatDate.year + formatDate.month + formatDate.date;
+  }
+
+  getTodayTask(uid: string) {
+    const today = this.formatToday();
+    return this.db.doc(`users/${uid}/tasks/${today}`).valueChanges();
   }
 
   createTask(uid: string, taskTitle: string): Promise<void> {
     const taskId = this.db.createId();
-    return this.db.doc(`users/${uid}/tasks/${taskId}`).set({
+    const createDate = this.formatToday();
+    return this.db.doc(`users/${uid}/tasks/${createDate}`).set({
       id: taskId,
       title: taskTitle,
       isComplate: false,
+      createDate,
       createdAt: firestore.Timestamp.now(),
+    });
+  }
+
+  complateTask(uid: string, createDate: string) {
+    return this.db.doc(`users/${uid}/tasks/${createDate}`).update({
+      isComplate: true
     });
   }
 }

--- a/src/app/welcome/welcome.module.ts
+++ b/src/app/welcome/welcome.module.ts
@@ -4,11 +4,10 @@ import { CommonModule } from '@angular/common';
 import { WelcomeRoutingModule } from './welcome-routing.module';
 import { WelcomeComponent } from './welcome/welcome.component';
 import { MatCardModule } from '@angular/material/card';
-import { MatButtonModule } from '@angular/material/button';
 import { HeroComponent } from './hero/hero.component';
 
 @NgModule({
   declarations: [WelcomeComponent, HeroComponent],
-  imports: [CommonModule, WelcomeRoutingModule, MatCardModule, MatButtonModule],
+  imports: [CommonModule, WelcomeRoutingModule, MatCardModule],
 })
 export class WelcomeModule {}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@500&display=swap');
+// @import url('https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@700&display=swap');
+// @import url('https://fonts.googleapis.com/css2?family=Kosugi+Maru&display=swap');
 @import "variables";
 @import "mixins";
 


### PR DESCRIPTION
fix #18 

お疲れ様です！
お手隙の際にご確認よろしくお願いいたします。

## セルフチェック

- [ ] 開発途中のコメントアウトが残っていない
- [ ] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ
![localhost_4200_ (9)](https://user-images.githubusercontent.com/46749854/93906417-22608180-fd37-11ea-8e84-9c97d9e46ed7.png)

## 作業概要
- 当日のタスク取得表示
- 完了報告ボタンの機能実装
- mypageのスタイル修正
- ヘッダーのボタンデザイン差し替え
- ヘッダーロゴを仮設置

## 備考
- 当日のタスク取得については、取得するサブコレクションのidが必要なため、日付をidとして使用しました。
- ヘッダーロゴは、現在webフォントで表示。fix後に画像化の予定です。
