### PR TITLE
fix(app):headerにz-indexを指定

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -4,6 +4,7 @@
   top: 0;
   left: 0;
   right: 0;
+  z-index: 100;
 }
 
 .l-wrap {


### PR DESCRIPTION
fix #32 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ
修正前
<img width="365" alt="スクリーンショット 2020-09-28 8 42 34" src="https://user-images.githubusercontent.com/46749854/94378771-01e55c80-0167-11eb-860d-0277461441bc.png">

修正後
<img width="365" alt="スクリーンショット 2020-09-28 8 43 13" src="https://user-images.githubusercontent.com/46749854/94378794-0c9ff180-0167-11eb-9c19-956eb74480a6.png">


## 作業概要

ボタン等がヘッダーにのめり込んでしまう現象を修正しました。
